### PR TITLE
Add community and personal trends pages

### DIFF
--- a/src/components/trends/EnergyTrendChart.jsx
+++ b/src/components/trends/EnergyTrendChart.jsx
@@ -1,0 +1,42 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { demoMoodEnergyData } from '../../demo-data/trends/personalTrends';
+
+export default function EnergyTrendChart() {
+  const data = demoMoodEnergyData.map((d) => ({
+    date: d.dateISO,
+    energy: d.energy,
+  }));
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-lg font-semibold mb-2">Energy Levels</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={(date) =>
+                new Date(date).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })
+              }
+            />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="energy" stroke="#F59E0B" strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/trends/MedsTakenTimeChart.jsx
+++ b/src/components/trends/MedsTakenTimeChart.jsx
@@ -1,0 +1,29 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { demoMedsTakenTimeData } from '../../demo-data/trends/personalTrends';
+
+export default function MedsTakenTimeChart() {
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-lg font-semibold mb-2">Meds Taken Time</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={demoMedsTakenTimeData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="time" />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="count" fill="#6366F1" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/trends/MoodTrendChart.jsx
+++ b/src/components/trends/MoodTrendChart.jsx
@@ -1,0 +1,47 @@
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { demoMoodEnergyData } from '../../demo-data/trends/personalTrends';
+
+export default function MoodTrendChart() {
+  const data = demoMoodEnergyData.map((d) => ({
+    date: d.dateISO,
+    mood: d.mood * 20,
+  }));
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-lg font-semibold mb-2">Mood Over Time</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={(date) =>
+                new Date(date).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })
+              }
+            />
+            <YAxis domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
+            <Tooltip />
+            <Line
+              type="monotone"
+              dataKey="mood"
+              stroke="#1B59AE"
+              strokeWidth={2}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/trends/SideEffectsHeatmap.jsx
+++ b/src/components/trends/SideEffectsHeatmap.jsx
@@ -1,0 +1,65 @@
+import { demoSideEffectsData } from '../../demo-data/trends/personalTrends';
+
+function getLast7Days() {
+  const today = new Date();
+  const dates = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - i);
+    dates.push(d.toISOString().split('T')[0]);
+  }
+  return dates;
+}
+
+export default function SideEffectsHeatmap() {
+  const days = getLast7Days();
+  const effects = ['headache', 'nausea', 'insomnia'];
+
+  const data = effects.map((effect) => {
+    const row = { effect };
+    days.forEach((day) => {
+      const entry = demoSideEffectsData.find((d) => d.dateISO === day) || {};
+      row[day] = entry[effect] || 0;
+    });
+    return row;
+  });
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-lg font-semibold mb-2">Side Effects Heatmap</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Effect</th>
+              {days.map((d) => (
+                <th key={d} className="px-2 py-1">
+                  {new Date(d).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row) => (
+              <tr key={row.effect} className="text-center">
+                <td className="px-2 py-1 text-left capitalize">{row.effect}</td>
+                {days.map((d) => (
+                  <td key={d} className="px-2 py-1">
+                    <span
+                      className={`inline-block w-4 h-4 rounded ${
+                        row[d] ? 'bg-red-500' : 'bg-gray-200'
+                      }`}
+                    ></span>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/trends/SleepTrendChart.jsx
+++ b/src/components/trends/SleepTrendChart.jsx
@@ -1,0 +1,42 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { demoSleepData } from '../../demo-data/trends/personalTrends';
+
+export default function SleepTrendChart() {
+  const data = demoSleepData.map((d) => ({
+    date: d.dateISO,
+    hours: d.hours,
+  }));
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-lg font-semibold mb-2">Sleep Totals</h2>
+      <div className="h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              tickFormatter={(date) =>
+                new Date(date).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })
+              }
+            />
+            <YAxis />
+            <Tooltip />
+            <Bar dataKey="hours" fill="#10B981" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/demo-data/community/communityInsights.js
+++ b/src/demo-data/community/communityInsights.js
@@ -1,0 +1,30 @@
+export const communityQuote =
+  "Users who log side effects weekly see 20% more consistent mood scores.";
+
+export const broadInsights = [
+  "78% took all doses last week",
+  "Most common side effect: Mild headache",
+  "Avg. sleep duration last month: 7.2 hours",
+  "Top mood improvement strategy: Journaling",
+];
+
+export const medicationInsights = {
+  adderall: {
+    medication: "Adderall",
+    insights: [
+      "Most common side effect: Dry Mouth",
+      "Avg. mood rating: 3.2/5",
+      "62% take in morning",
+      "40% report increased focus",
+    ],
+  },
+  sertraline: {
+    medication: "Sertraline",
+    insights: [
+      "Most common side effect: Nausea",
+      "Avg. mood rating: 3.8/5",
+      "70% take with food",
+      "55% report improved sleep",
+    ],
+  },
+};

--- a/src/demo-data/trends/personalTrends.js
+++ b/src/demo-data/trends/personalTrends.js
@@ -1,0 +1,15 @@
+import {
+  demoMoodEnergyData,
+  demoSleepData,
+  demoSideEffectsData,
+} from '../dashboard/DashboardData';
+
+export { demoMoodEnergyData, demoSleepData, demoSideEffectsData };
+
+export const demoMedsTakenTimeData = [
+  { time: '6 AM', count: 1 },
+  { time: '7 AM', count: 3 },
+  { time: '8 AM', count: 2 },
+  { time: '12 PM', count: 1 },
+  { time: '6 PM', count: 2 },
+];

--- a/src/pages/CommunityPage.jsx
+++ b/src/pages/CommunityPage.jsx
@@ -1,8 +1,63 @@
+import { useState } from 'react';
+import {
+  communityQuote,
+  broadInsights,
+  medicationInsights,
+} from '../demo-data/community/communityInsights';
+import { demoMedications } from '../demo-data/medications/Medications';
+
 export default function CommunityPage() {
+  const [selected, setSelected] = useState('adderall');
+  const meds = demoMedications.map((m) => m.commonName.toLowerCase());
+  const insight = medicationInsights[selected];
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Community</h1>
-      <p>This is the community insights screen.</p>
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">Community Insights</h1>
+      <p className="mb-6 italic text-gray-700">{communityQuote}</p>
+
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 mb-6">
+        <h2 className="text-xl font-semibold mb-2">Broad Insights</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {broadInsights.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-200 mb-6">
+        <h2 className="text-xl font-semibold mb-2">Tailored Insights</h2>
+        <div className="mb-3">
+          <label className="mr-2 font-medium">Medication:</label>
+          <select
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            className="border rounded px-2 py-1"
+          >
+            {meds.map((name) => (
+              <option key={name} value={name}>
+                {name.charAt(0).toUpperCase() + name.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+        {insight && (
+          <ul className="list-disc list-inside space-y-1">
+            {insight.insights.map((i) => (
+              <li key={i}>{i}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex gap-4">
+        <button className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700">
+          View Community Trends
+        </button>
+        <button className="px-4 py-2 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700">
+          Share My Progress
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/TrendsPage.jsx
+++ b/src/pages/TrendsPage.jsx
@@ -1,7 +1,12 @@
+import MoodTrendChart from '../components/trends/MoodTrendChart';
+import SleepTrendChart from '../components/trends/SleepTrendChart';
+import EnergyTrendChart from '../components/trends/EnergyTrendChart';
+import MedsTakenTimeChart from '../components/trends/MedsTakenTimeChart';
+import SideEffectsHeatmap from '../components/trends/SideEffectsHeatmap';
+
 export default function TrendsPage() {
   return (
     <div className="p-6 max-w-6xl mx-auto">
-      {/* Header */}
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-800">Trends</h1>
         <button className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700">
@@ -9,111 +14,28 @@ export default function TrendsPage() {
         </button>
       </div>
 
-      {/* Filter Tabs */}
-      <div className="flex gap-2 mb-6">
-        {['Mood', 'Energy', 'Sleep', 'Side Effects'].map((tab) => (
-          <button
-            key={tab}
-            className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg font-medium hover:bg-gray-300"
-          >
-            {tab}
-          </button>
-        ))}
+      <div className="mb-4">
+        <label className="mr-2 font-medium">Time Range:</label>
+        <select className="border rounded px-2 py-1">
+          <option>Last 7 Days</option>
+          <option>Last Month</option>
+        </select>
       </div>
 
-      {/* Charts Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        {[
-          'Mood Over Time',
-          'Energy Over Time',
-          'Sleep Over Time',
-          'Side Effects Over Time',
-        ].map((title) => (
-          <div
-            key={title}
-            className="bg-white p-6 rounded-lg shadow-sm border border-gray-200"
-          >
-            <h2 className="text-xl font-semibold mb-4">{title}</h2>
-            <div className="h-64 bg-gray-50 rounded flex items-center justify-center">
-              <span className="text-gray-400">Chart Placeholder</span>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        {[
-          {
-            label: 'Average Mood',
-            value: '7.2/10',
-            trend: '↑ 12% from last month',
-          },
-          { label: 'Average Sleep', value: '7.5h', trend: '→ Consistent' },
-          {
-            label: 'Medication Adherence',
-            value: '85%',
-            trend: '↑ 5% from last month',
-          },
-        ].map((stat) => (
-          <div
-            key={stat.label}
-            className="bg-white p-6 rounded-lg shadow-sm border border-gray-200"
-          >
-            <h3 className="text-lg font-semibold mb-2">{stat.label}</h3>
-            <div className="text-2xl font-bold text-gray-800 mb-1">
-              {stat.value}
-            </div>
-            <p
-              className={`text-sm ${stat.trend.startsWith('↑') ? 'text-green-600' : stat.trend.startsWith('→') ? 'text-blue-600' : 'text-gray-600'}`}
-            >
-              {stat.trend}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* Insights */}
-      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
-        <h2 className="text-xl font-semibold mb-4">Insights</h2>
-
-        <div className="space-y-4">
-          <div className="flex items-start gap-3 p-4 bg-blue-50 rounded-lg">
-            <span className="text-blue-600 text-xl">💡</span>
-            <div>
-              <p className="font-medium text-gray-800">
-                Your mood tends to be higher on days when you sleep 7+ hours
-              </p>
-              <p className="text-sm text-gray-600 mt-1">
-                Consider maintaining a consistent sleep schedule
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-start gap-3 p-4 bg-green-50 rounded-lg">
-            <span className="text-green-600 text-xl">📈</span>
-            <div>
-              <p className="font-medium text-gray-800">
-                Your energy levels have improved by 15% this month
-              </p>
-              <p className="text-sm text-gray-600 mt-1">
-                Great progress! Keep up the current routine
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-start gap-3 p-4 bg-yellow-50 rounded-lg">
-            <span className="text-yellow-600 text-xl">⚠️</span>
-            <div>
-              <p className="font-medium text-gray-800">
-                You missed medications 3 times this week
-              </p>
-              <p className="text-sm text-gray-600 mt-1">
-                Consider setting up reminders to improve adherence
-              </p>
-            </div>
-          </div>
+        <MoodTrendChart />
+        <SleepTrendChart />
+        <EnergyTrendChart />
+        <MedsTakenTimeChart />
+        <div className="md:col-span-2">
+          <SideEffectsHeatmap />
         </div>
+      </div>
+
+      <div className="text-center">
+        <button className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700">
+          Generate Full Report
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add demo data for community insights and personal trends
- scaffold charts for trends page using demo data
- implement basic community insights page

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6873aecfc980832c8444fc1c04a6f77b