### PR TITLE
Add mobile dropdown for nav

### DIFF
--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -1,7 +1,10 @@
 import logoIcon from '../../assets/branding/logo-512-tight-crop.png';
 import { Link } from 'react-router-dom';
-import { UserIcon } from '@heroicons/react/24/solid';
+import { useState } from 'react';
+import { Bars3Icon, XMarkIcon, UserIcon } from '@heroicons/react/24/solid';
+
 export default function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <header
       className="flex items-center justify-between px-4 py-4 border-b shadow-sm"
@@ -17,6 +20,18 @@ export default function Header() {
         </a>
       </div>
       <div className="flex items-center space-x-3 md:space-x-8">
+        <button
+          className="md:hidden p-2"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle menu"
+        >
+          {menuOpen ? (
+            <XMarkIcon className="w-6 h-6 text-[#1B59AE]" />
+          ) : (
+            <Bars3Icon className="w-6 h-6 text-[#1B59AE]" />
+          )}
+        </button>
+
         <nav className="hidden md:flex space-x-3 ml-auto">
           <Link
             to="/dashboard"
@@ -56,6 +71,48 @@ export default function Header() {
           <UserIcon className="w-8 h-8 text-gray-500" />
         </div>
       </div>
+      {/* Mobile navigation */}
+      <nav
+        className={`md:hidden ${
+          menuOpen ? 'flex' : 'hidden'
+        } flex-col space-y-2 px-4 pb-4 bg-[#A3B5AC] border-b shadow-sm w-full absolute left-0 top-full`}
+      >
+        <Link
+          to="/dashboard"
+          onClick={() => setMenuOpen(false)}
+          className="px-3 py-2 rounded text-sm font-semibold text-[#1B59AE] border-2 border-[#1B59AE] hover:bg-teal-500 hover:text-white transition"
+        >
+          Dashboard
+        </Link>
+        <Link
+          to="/log-entry"
+          onClick={() => setMenuOpen(false)}
+          className="px-3 py-2 rounded text-sm font-semibold text-[#1B59AE] border-2 border-[#1B59AE] hover:bg-teal-500 hover:text-white transition"
+        >
+          Log Entry
+        </Link>
+        <Link
+          to="/medications"
+          onClick={() => setMenuOpen(false)}
+          className="px-3 py-2 rounded text-sm font-semibold text-[#1B59AE] border-2 border-[#1B59AE] hover:bg-teal-500 hover:text-white transition"
+        >
+          My Medications
+        </Link>
+        <Link
+          to="/trends"
+          onClick={() => setMenuOpen(false)}
+          className="px-3 py-2 rounded text-sm font-semibold text-[#1B59AE] border-2 border-[#1B59AE] hover:bg-teal-500 hover:text-white transition"
+        >
+          Trends
+        </Link>
+        <Link
+          to="/community"
+          onClick={() => setMenuOpen(false)}
+          className="px-3 py-2 rounded text-sm font-semibold text-[#1B59AE] border-2 border-[#1B59AE] hover:bg-teal-500 hover:text-white transition"
+        >
+          Community
+        </Link>
+      </nav>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add menu toggle state in `Header`
- show hamburger/X icons depending on mobile menu state
- display dropdown navigation on small screens

## Testing
- `npm install` *(fails: unable to fetch packages)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0ddb340832c8e10f09470769f1a