### PR TITLE
Add settings and admin scaffolds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import TrendsPage from './pages/TrendsPage';
 import CommunityPage from './pages/CommunityPage';
 import AccountPage from './pages/AccountPage';
 import RegisterPage from './pages/RegisterPage';
+import SettingsPage from './pages/SettingsPage';
+import AdminPage from './pages/AdminPage';
 import Header from './components/shared/Header';
 import Footer from './components/shared/Footer';
 import PrivacyPolicy from './components/shared/PrivacyPolicy';
@@ -26,6 +28,8 @@ export default function App() {
           <Route path="/community" element={<CommunityPage />} />
           <Route path="/account" element={<AccountPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/admin" element={<AdminPage />} />
           <Route path="/privacy" element={<PrivacyPolicy />} />
           <Route path="/terms" element={<TermsOfService />} />
         </Routes>

--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -50,9 +50,9 @@ export default function Header() {
           </Link>
         </nav>
         <div className="flex items-center space-x-2">
-          <button className="text-sm text-gray-600 hover:text-gray-800">
+          <Link to="/settings" className="text-sm text-gray-600 hover:text-gray-800">
             Settings
-          </button>
+          </Link>
           <UserIcon className="w-8 h-8 text-gray-500" />
         </div>
       </div>

--- a/src/demo-data/admin/AdminMetrics.js
+++ b/src/demo-data/admin/AdminMetrics.js
@@ -1,0 +1,7 @@
+export const demoAdminMetrics = {
+  totalUsers: 1532,
+  activeUsers: 480,
+  logsRecorded: 12942,
+  reportsReviewed: 36,
+  pendingReports: 12,
+};

--- a/src/demo-data/settings/SettingsData.js
+++ b/src/demo-data/settings/SettingsData.js
@@ -1,0 +1,19 @@
+export const demoAccountInfo = {
+  name: 'John Doe',
+  email: 'john@example.com',
+};
+
+export const demoNotificationSettings = {
+  medicationReminders: true,
+  refillReminders: true,
+  manufacturerAlerts: true,
+};
+
+export const demoSharingSettings = {
+  shareInsights: true,
+};
+
+export const demoIntegrationSettings = {
+  healthAppsConnected: false,
+  pharmacySynced: false,
+};

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,0 +1,59 @@
+import { demoAdminMetrics } from '../demo-data/admin/AdminMetrics';
+
+export default function AdminPage() {
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-6">Admin Dashboard</h1>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <div className="bg-white p-4 rounded-lg shadow text-center">
+          <p className="text-sm text-gray-500">Total Users</p>
+          <p className="text-2xl font-semibold">{demoAdminMetrics.totalUsers}</p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow text-center">
+          <p className="text-sm text-gray-500">Active This Month</p>
+          <p className="text-2xl font-semibold">{demoAdminMetrics.activeUsers}</p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow text-center">
+          <p className="text-sm text-gray-500">Logs Recorded</p>
+          <p className="text-2xl font-semibold">{demoAdminMetrics.logsRecorded}</p>
+        </div>
+        <div className="bg-white p-4 rounded-lg shadow text-center">
+          <p className="text-sm text-gray-500">Reports Reviewed</p>
+          <p className="text-2xl font-semibold">{demoAdminMetrics.reportsReviewed}</p>
+        </div>
+      </div>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">User Management</h2>
+        <input
+          type="text"
+          placeholder="Search users by email or ID"
+          className="w-full border p-2 rounded mb-4"
+        />
+        <p className="text-sm text-gray-500">User list placeholder</p>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Content Moderation</h2>
+        <p>Pending Reports: {demoAdminMetrics.pendingReports}</p>
+        <button className="text-blue-600 text-sm mt-2">View Reports</button>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">System Monitoring</h2>
+        <p className="text-sm text-gray-500">Placeholder for monitoring widgets</p>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Data &amp; Privacy</h2>
+        <p className="text-sm text-gray-500">Placeholder controls for data export and retention</p>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow">
+        <h2 className="text-xl font-semibold mb-2">Audit Logs</h2>
+        <p className="text-sm text-gray-500">Admin action log placeholder</p>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+import {
+  demoAccountInfo,
+  demoNotificationSettings,
+  demoSharingSettings,
+  demoIntegrationSettings,
+} from '../demo-data/settings/SettingsData';
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-6">Account Settings</h1>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Profile</h2>
+        <div className="flex items-center space-x-4">
+          <div className="h-12 w-12 rounded-full bg-gray-300" />
+          <div className="flex-1">
+            <p className="font-medium">{demoAccountInfo.name}</p>
+            <p className="text-sm text-gray-600">{demoAccountInfo.email}</p>
+          </div>
+          <button className="text-sm text-blue-600">Edit Profile</button>
+        </div>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Notifications</h2>
+        <ul className="space-y-2">
+          {Object.entries(demoNotificationSettings).map(([key, value]) => (
+            <li key={key} className="flex justify-between items-center">
+              <span className="capitalize">{key.replace(/([A-Z])/g, ' $1')}</span>
+              <span className="text-sm text-gray-600">
+                {value ? 'On' : 'Off'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Community Sharing</h2>
+        <p className="flex justify-between items-center">
+          <span>Share anonymized insights</span>
+          <span className="text-sm text-gray-600">
+            {demoSharingSettings.shareInsights ? 'On' : 'Off'}
+          </span>
+        </p>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2">Integrations</h2>
+        <ul className="space-y-2">
+          {Object.entries(demoIntegrationSettings).map(([key, value]) => (
+            <li key={key} className="flex justify-between items-center">
+              <span className="capitalize">{key.replace(/([A-Z])/g, ' $1')}</span>
+              <span className="text-sm text-gray-600">
+                {value ? 'Connected' : 'Not Connected'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="bg-white p-4 rounded-lg shadow mb-6">
+        <h2 className="text-xl font-semibold mb-2 text-red-600">Danger Zone</h2>
+        <button className="text-red-600 text-sm">Delete My Account</button>
+      </section>
+
+      <div className="flex justify-between items-center mt-8">
+        <Link to="/admin" className="text-sm text-blue-600 underline">
+          Admin
+        </Link>
+        <button className="text-sm text-gray-600">Logout</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold SettingsPage and AdminPage using demo data
- link Settings in main nav and register routes
- add demo user settings and admin metrics data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873c3c9ebf8832c94d3799c66cf5a74